### PR TITLE
Fix typo in libinput.man

### DIFF
--- a/man/libinput.man
+++ b/man/libinput.man
@@ -123,7 +123,7 @@ Enables or disables tap-to-click behavior.
 .BI "Option \*qTappingDragLock\*q \*q" bool \*q
 Enables or disables drag lock during tapping behavior. When enabled, a
 finger up during tap-and-drag will not immediately release the button. If
-the finger is set down again within the timeout, the draging process
+the finger is set down again within the timeout, the dragging process
 continues.
 .TP 7
 .BI "Option \*qDisableWhileTyping\*q \*q" bool \*q


### PR DESCRIPTION
Correct typo. Draging to dragging.